### PR TITLE
Add TSMC MA strategy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Trading Strategy
+
+## TSMC Moving Average Example
+
+The `TW/ma_strategy_2330.py` script downloads historical data for TSMC (ticker `2330`) from Yahoo Finance and prints simple moving-average crossover signals.
+
+Run the script with Python:
+
+```bash
+python TW/ma_strategy_2330.py
+```
+
+The script requires the `pandas` and `yfinance` packages.

--- a/TW/ma_strategy_2330.py
+++ b/TW/ma_strategy_2330.py
@@ -1,0 +1,29 @@
+import pandas as pd
+import yfinance as yf
+
+
+def fetch_stock_data(symbol: str, start: str, end: str) -> pd.DataFrame:
+    """Fetch historical stock data from Yahoo Finance."""
+    data = yf.download(symbol + ".TW", start=start, end=end)
+    return data
+
+
+def ma_strategy(data: pd.DataFrame, short_window: int = 5, long_window: int = 20) -> pd.DataFrame:
+    """Calculate moving average crossover signals."""
+    df = data.copy()
+    df["MA_short"] = df["Close"].rolling(window=short_window).mean()
+    df["MA_long"] = df["Close"].rolling(window=long_window).mean()
+    df["Signal"] = 0
+    df.loc[df["MA_short"] > df["MA_long"], "Signal"] = 1
+    df.loc[df["MA_short"] < df["MA_long"], "Signal"] = -1
+    df["Position"] = df["Signal"].diff()
+    return df
+
+
+if __name__ == "__main__":
+    symbol = "2330"  # Taiwan Semiconductor Manufacturing Company
+    start_date = "2020-01-01"
+    end_date = "2023-12-31"
+    stock_data = fetch_stock_data(symbol, start=start_date, end=end_date)
+    result = ma_strategy(stock_data)
+    print(result[["Close", "MA_short", "MA_long", "Position"]].dropna().tail())


### PR DESCRIPTION
## Summary
- add MA crossover script for TSMC (2330) under `TW/`
- document usage in README

## Testing
- `python3 -m py_compile TW/ma_strategy_2330.py`
- `python3 TW/ma_strategy_2330.py` *(fails: ModuleNotFoundError: No module named 'pandas')*